### PR TITLE
test: improve test coverage for query validation and `retrieve=False`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .coverage
+tests/site-config.json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,13 @@ ignore = [
     "D213",
     "E501",    # Disable line-too-long as this is taken care of by the formatter.
 ]
+[tool.ruff.lint.per-file-ignores]
+"tests/**.py" = [
+    "S101",     # Use of assert in tests code is required.
+    "T20",      # Printing things can help with debugging tests.
+    "SLF001",   # Testing private members is ok
+    "PLR2004",  # Magic values in tests are fine.
+]
 
 [tool.ruff.lint.isort]
 known-first-party = ["snakemake-storage-plugin-rucio"]

--- a/snakemake_storage_plugin_rucio/__init__.py
+++ b/snakemake_storage_plugin_rucio/__init__.py
@@ -152,7 +152,7 @@ class StorageProvider(StorageProviderBase):
             ExampleQuery(
                 query="rucio://myscope/myfile.txt",
                 type=QueryType.ANY,
-                description="A file in a Rucio scope.",
+                description='The file "myfile.txt" in Rucio scope "myscope".',
             ),
         ]
 
@@ -198,7 +198,7 @@ class StorageProvider(StorageProviderBase):
             # - rucio:/scope/file
             # - /scope/file
             # - scope/file
-            path_elements = parsed.path.lstrip("/").split("/")
+            path_elements = [p for p in parsed.path.strip("/").split("/") if p]
             if (bool(parsed.netloc) and len(path_elements) == 1) or (
                 not parsed.netloc and len(path_elements) == 2  # noqa: PLR2004
             ):
@@ -206,9 +206,8 @@ class StorageProvider(StorageProviderBase):
                     query=query,
                     valid=True,
                 )
-
-        # Accept any valid URL, to be used when retrieve=False.
-        if parsed.scheme and parsed.netloc:
+        elif parsed.scheme and parsed.netloc:
+            # Accept any valid URL, to be used when retrieve=False.
             return StorageQueryValidationResult(
                 query=query,
                 valid=True,

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import importlib
 import json
 import os
 from datetime import UTC, datetime
@@ -34,7 +33,7 @@ def _load_site_config() -> dict:
         "upload_rse": "XRD1",
         "streaming_protocol": "root",
     }
-    traversible = importlib.resources.files() / "site-config.json"
+    traversible = Path(__file__).parent / "site-config.json"
 
     try:
         site_config = json.loads(traversible.read_text(encoding="utf-8"))


### PR DESCRIPTION
Make tests more configureable, for easier testing with another Rucio server than what is provided by the Rucio demo setup used in CI. To configure, create a file `tests/site-config.json` with for example the following content:
```json 
{
    "scope": "testing",
    "file": "test101.txt",
    "download_rse": null,
    "upload_rse": "IN2P3_XROOT"
}
```

Improves test coverage for query validation and `retrieve=False`.