### PR TITLE
fix: upload under self.file did instead of letting it use local_path() basename

### DIFF
--- a/snakemake_storage_plugin_rucio/__init__.py
+++ b/snakemake_storage_plugin_rucio/__init__.py
@@ -425,6 +425,7 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
                 {
                     "path": self.local_path(),
                     "did_scope": self.scope,
+                    "did_name": self.file,
                     "dataset_scope": self.scope,
                     "dataset_name": self.provider.settings.upload_dataset,
                     "rse": self.provider.settings.upload_rse,

--- a/snakemake_storage_plugin_rucio/__init__.py
+++ b/snakemake_storage_plugin_rucio/__init__.py
@@ -425,7 +425,6 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
                 {
                     "path": self.local_path(),
                     "did_scope": self.scope,
-                    "did_name": self.file,
                     "dataset_scope": self.scope,
                     "dataset_name": self.provider.settings.upload_dataset,
                     "rse": self.provider.settings.upload_rse,

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -249,3 +249,15 @@ class TestStorageWrite(TestStorageRucioBase):
             NotImplementedError, match="Rucio does not support deleting files."
         ):
             obj.remove()
+
+    def test_upload_with_different_local_filename(self, tmp_path: Path) -> None:
+        """Test that upload uses self.file as did_name even when local path has different filename."""
+        obj = self.get_storage_object(tmp_path)
+        local_path = tmp_path / "local_file.txt"
+        local_path.write_text("content")
+        obj.set_local_path(local_path)
+
+        obj.store_object()
+
+        obj = self.get_storage_object(tmp_path, obj.query)
+        assert obj.exists()


### PR DESCRIPTION
There is a case in upload_sources()
https://github.com/snakemake/snakemake/blob/b88171cea0752b65cb6687906f7778c7f229c93d/src/snakemake/workflow.py#L346-L364
when local file is generated e.g. /tmp/tmpt5n7ybk4snakemake-sources.tar.xz (based on set_local_path), but intended to be uploaded as scope:snakemake-workflow-sources.bdc1ea84d7fa16baf4ca81f1e15877fa0e32a3dd812951b81e89d48b5b9a3cda.tar.xz (based on query)

This ensures that the correct path is used.