### PR TITLE
feat: make store_object no-op if the file is already uploaded

### DIFF
--- a/snakemake_storage_plugin_rucio/__init__.py
+++ b/snakemake_storage_plugin_rucio/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import dataclasses
+import hashlib
 import inspect
 import random
 import re
@@ -146,13 +147,13 @@ class StorageProvider(StorageProviderBase):
             if k in valid_client_args
         }
 
-        logger = get_logger()
-        self.client = rucio.client.Client(logger=logger, **client_kwargs)
+        self.logger = get_logger()
+        self.client = rucio.client.Client(logger=self.logger, **client_kwargs)
         self.dclient = rucio.client.downloadclient.DownloadClient(
-            self.client, logger=logger
+            self.client, logger=self.logger
         )
         self.uclient = rucio.client.uploadclient.UploadClient(
-            self.client, logger=logger
+            self.client, logger=self.logger
         )
 
     @classmethod
@@ -406,15 +407,31 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
 
     def store_object(self) -> None:
         """Upload the file."""
-        if self.exists():
-            msg = f'File "{self.scope}/{self.file}" already exists on Rucio'
-            raise ValueError(msg)
         if self.provider.settings.upload_rse is None:
             msg = "Please specify the `upload_rse`."
             raise ValueError(msg)
         if self.provider.settings.upload_dataset is None:
             msg = "Please specify the `upload_dataset`."
             raise ValueError(msg)
+
+        try:
+            did_info = self.client.get_did(scope=self.scope, name=self.file)
+        except rucio.common.exception.DataIdentifierNotFound:
+            pass
+        else:
+            with self.local_path().open("rb") as fp:
+                m = hashlib.file_digest(fp, "md5")
+            if "md5" in did_info and did_info["md5"] == m.hexdigest():
+                self.provider.logger.debug(
+                    "File %s:%s with the same hash already exists on Rucio, skipping upload",
+                    self.scope,
+                    self.file,
+                )
+                # Nothing to do
+                return
+            msg = f'File "{self.scope}/{self.file}" already exists on Rucio'
+            raise ValueError(msg)
+
         self._store_object()
 
     @retry_decorator

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -221,6 +221,8 @@ class TestStorageWrite(TestStorageRucioBase):
         scope = SITE_CONFIG["scope"]
         file = SITE_CONFIG["file"]
         obj = self.get_storage_object(tmp_path, query=f"rucio://{scope}/{file}")
+        obj.local_path().parent.mkdir()
+        obj.local_path().write_text("content")
         with pytest.raises(
             ValueError, match=f'File "{scope}/{file}" already exists on Rucio'
         ):
@@ -261,3 +263,16 @@ class TestStorageWrite(TestStorageRucioBase):
 
         obj = self.get_storage_object(tmp_path, obj.query)
         assert obj.exists()
+
+    def test_upload_twice(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Test that uploading the same file second time is detected."""
+        obj = self.get_storage_object(tmp_path)
+        obj.local_path().parent.mkdir()
+        obj.local_path().write_text("content")
+
+        obj.store_object()
+        assert "already exists on Rucio" not in caplog.text
+        obj.store_object()
+        assert "already exists on Rucio" in caplog.text


### PR DESCRIPTION
This is useful for job source tarballs that Snakemake tries to re-upload. A typical case for this is Snakemake source tarball upload.